### PR TITLE
simplifying makefile & making it work on my macos

### DIFF
--- a/cpp/Makefile
+++ b/cpp/Makefile
@@ -3,17 +3,17 @@ LD=g++
 CPPFLAGS= -std=c++11 -O3 -ffast-math -ftree-vectorize 
 LDFLAGS= -shared
 
-%::%.cpp
-	$(CC) -c $< -o $@.o $(CFLAGS)
-	$(LD) $(LDFLAGS) $@.o -o $@_lib.so
-
-PP: ProbeParticle
-
-GU: GridUtils
-
-MP: Multipoles
-
 all: PP GU MP
 
+PP: ProbeParticle.o
+
+GU: GridUtils.o
+
+MP: Multipoles.o
+
+%.o::%.cpp
+	$(CC) -c $< -o $@ $(CFLAGS)
+	$(LD) $(LDFLAGS) $@ -o $*_lib.so
+
 clean:
-	rm *.o *.so *.pyc
+	rm -f *.o *.so *.pyc

--- a/cpp/Makefile
+++ b/cpp/Makefile
@@ -11,7 +11,9 @@ GU: GridUtils.o
 
 MP: Multipoles.o
 
-%.o::%.cpp
+# .o files depend on .cpp files with same prefix
+# $@ target, $< prerequisite, $* matched stencil
+%.o:: %.cpp
 	$(CC) -c $< -o $@ $(CFLAGS)
 	$(LD) $(LDFLAGS) $@ -o $*_lib.so
 

--- a/cpp/Makefile
+++ b/cpp/Makefile
@@ -1,18 +1,19 @@
 CC=g++
-CPPFLAGS=-std=c++11 -O3 -ffast-math -ftree-vectorize 
-CPPLFLAGS= $(CPPFLAGS) -shared -Wl,-soname
+LD=g++
+CPPFLAGS= -std=c++11 -O3 -ffast-math -ftree-vectorize 
+LDFLAGS= -shared
+
+%::%.cpp
+	$(CC) -c $< -o $@.o $(CFLAGS)
+	$(LD) $(LDFLAGS) $@.o -o $@_lib.so
+
+PP: ProbeParticle
+
+GU: GridUtils
+
+MP: Multipoles
 
 all: PP GU MP
-
-PP:
-	$(CC) $(CPPFLAGS) -c -fPIC ProbeParticle.cpp 
-	$(CC) $(CPPLFLAGS),ProbeParticle_lib.so -o ProbeParticle_lib.so ProbeParticle.o
-GU:
-	$(CC) $(CPPFLAGS) -c -fPIC GridUtils.cpp
-	$(CC) $(CPPLFLAGS),GridUtils_lib.so -o GridUtils_lib.so GridUtils.o
-MP:
-	$(CC) $(CPPFLAGS) -c -fPIC Multipoles.cpp
-	$(CC) $(CPPLFLAGS),Multipoles_lib.so -o Multipoles_lib.so Multipoles.o
 
 clean:
 	rm *.o *.so *.pyc


### PR DESCRIPTION
My g++ didn't know what to do with the -soname keyword. Is it really needed, as the name of the .so file is anyhow provided?

Anyhow, I have made some simplifications in the makefile that should make it both more flexible and easier to maintain.
It works fine using g++ 5.4.0 installed via macports on MacOS 10.10.5