### PR TITLE
Fix publish CI workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -57,37 +57,37 @@ jobs:
                   name: release-sdist
                   path: dist/*.tar.gz
 
-    # publish:
+    publish:
 
-    #     name: Build and publish on PyPI
-    #     if: startsWith(github.ref, 'refs/tags')
+        name: Build and publish on PyPI
+        if: startsWith(github.ref, 'refs/tags')
 
-    #     needs: [build_wheels, build_sdist]
-    #     runs-on: ubuntu-latest
+        needs: [build_wheels, build_sdist]
+        runs-on: ubuntu-latest
 
-    #     environment:
-    #         name: PyPI
-    #         url: https://pypi.org/project/ppafm/
+        environment:
+            name: PyPI
+            url: https://pypi.org/project/ppafm/
 
-    #     steps:
+        steps:
 
-    #         - uses: actions/download-artifact@v4.1.7
-    #           name: Download distribution artifact
-    #           with:
-    #               pattern: release-*
-    #               path: dist
-    #               merge-multiple: true
+            - uses: actions/download-artifact@v4.1.7
+              name: Download distribution artifact
+              with:
+                  pattern: release-*
+                  path: dist
+                  merge-multiple: true
 
-    #         - uses: softprops/action-gh-release@v1
-    #           name: Create release
-    #           if: startsWith(github.ref, 'refs/tags/v')
-    #           with:
-    #               files: |
-    #                   dist/*
-    #               generate_release_notes: true
+            - uses: softprops/action-gh-release@v1
+              name: Create release
+              if: startsWith(github.ref, 'refs/tags/v')
+              with:
+                  files: |
+                      dist/*
+                  generate_release_notes: true
 
-    #         - name: Publish distribution on PyPI
-    #           uses: pypa/gh-action-pypi-publish@release/v1
-    #           with:
-    #               user: __token__
-    #               password: ${{ secrets.PYPI_API_TOKEN }}
+            - name: Publish distribution on PyPI
+              uses: pypa/gh-action-pypi-publish@release/v1
+              with:
+                  user: __token__
+                  password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
The update to `upload-artifact` in #331 still left the publish workflow broken. This should fix it.

I was trying to make a new release, but this prevented it. I'll fix the tag to point to the fixed commit manually afterwards.