### PR TITLE
Wrap ix/iy in np.atleast_1d before set_data so Matplotlib ≥3.8

### DIFF
--- a/ppafm/GUIWidgets.py
+++ b/ppafm/GUIWidgets.py
@@ -147,7 +147,9 @@ class FigImshow(FigCanvas):
                     print("plotSlice: reset points")
             else:
                 for p, (ix, iy) in zip(self.axes.lines, points):
-                    p.set_data((ix, iy))
+                    x = np.atleast_1d(ix)
+                    y = np.atleast_1d(iy)
+                    p.set_data(x, y)
 
         if cbar_range:
             if self.cbar == None:


### PR DESCRIPTION
Wrap ix/iy in np.atleast_1d before set_data so Matplotlib ≥3.8 can accept scalars as sequences. Prevents "RuntimeError: x must be a sequence".

Previously, the error appeared after creating a df point on the window and then modifying any parameter in the GUI when using Matplotlib ≥3.8. 