### PR TITLE
Widen default force field lattice vector padding in AFMulator.

### DIFF
--- a/ppafm/ocl/AFMulator.py
+++ b/ppafm/ocl/AFMulator.py
@@ -722,7 +722,7 @@ def _get_params(file_path):
     return afmulator_params, sample_lvec
 
 
-def get_lvec(scan_window, pad=(3.0, 3.0, 3.0), tipR0=(0.0, 0.0, 3.0), pixPerAngstrome=10):
+def get_lvec(scan_window, pad=(3.0, 3.0, 5.0), tipR0=(0.0, 0.0, 3.0), pixPerAngstrome=10):
     pad = np.array(pad)
     tipR0 = np.array(tipR0)
     center = (np.array(scan_window[0]) + np.array(scan_window[1])) / 2


### PR DESCRIPTION
Fixes #365

We had a system with @huangchieh where the default padding on the force field box in AFMulator was not enough so that the probe particle fell out of the box, causing some artifacts at the edge of the image. This simply adds a bit more space to the default padding.
