### PR TITLE
Add feature to enable overlaying the atoms to the generated AFM images. 

### DIFF
--- a/ppafm/ocl/AFMulator.py
+++ b/ppafm/ocl/AFMulator.py
@@ -656,7 +656,7 @@ class AFMulator:
 
         for key in ["F", "slices", "extent", "zs", "cmap"]:
             if key in plot_kwargs:
-                warnings.warn(f"plot_images(): '{key}' found in plot_kwargs but is  set internally, removing from plot_kwargs.")
+                warnings.warn(f"\n plot_images(): '{key}' found in plot_kwargs but is  set internally, removing from plot_kwargs.")
                 del plot_kwargs[key]
         plotImages(os.path.join(outdir, prefix), X, slices=list(range(0, len(X))), zs=zTips, extent=extent, cmap=self.colorscale, **plot_kwargs)
 


### PR DESCRIPTION
Fix #363 
1. Pass the `atoms` to the method `eval` in AFMulator.  
2. To distinguish from the default output, `prefix` can be used when overlaying the atoms.  