### PR TITLE
Fix broken tip displacement calculation

### DIFF
--- a/examples/FFPB_KPFM/run.sh
+++ b/examples/FFPB_KPFM/run.sh
@@ -16,7 +16,7 @@ ppafm-generate-ljff -i LOCPOT_V0.xsf
 echo
 
 echo "Tip Relaxation"
-ppafm-relaxed-scan --Vrange -0.5 0.5 3
+ppafm-relaxed-scan --Vrange -0.5 0.5 3 --disp
 echo
 
 echo "Plotting"

--- a/ppafm/HighLevel.py
+++ b/ppafm/HighLevel.py
@@ -28,11 +28,6 @@ def symGauss(Evib, E0, w):
     return Gauss(Evib, E0, w) - Gauss(Evib, -E0, w)
 
 
-def meshgrid3d(xs, ys, zs):
-    Xs, Ys, Zs = np.zeros()
-    Xs, Ys = np.meshgrid(xs, ys)
-
-
 def trjByDir(n, d, p0):
     trj = np.zeros((n, 3))
     trj[:, 0] = p0[0] + (np.arange(n)[::-1]) * d[0]
@@ -173,7 +168,7 @@ def perform_relaxation(
 
     if bPPdisp:
         PPdisp = PPpos.copy()
-        init_pos = np.array(np.meshgrid(xTips, yTips, zTips)).transpose(3, 1, 2, 0) + np.array([parameters.r0Probe[0], parameters.r0Probe[1], -parameters.r0Probe[2]])
+        init_pos = np.array(np.meshgrid(xTips, yTips, zTips)).transpose(2, 1, 3, 0) + np.array([parameters.r0Probe[0], parameters.r0Probe[1], -parameters.r0Probe[2]])
         PPdisp -= init_pos
     else:
         PPdisp = None

--- a/ppafm/cpp/ProbeParticle.cpp
+++ b/ppafm/cpp/ProbeParticle.cpp
@@ -685,7 +685,7 @@ DLLEXPORT int relaxTipStrokes_omp( int nx, int ny, int probeStart, int relaxAlg,
     #pragma omp parallel for collapse(2) shared( nx, ny, probeStart, relaxAlg, nstep, rTips_, rs_, fs_, ndone )
     for (int ix=0; ix<nx; ix++){
         for (int iy=0; iy<ny; iy++){
-            int ioff = (ix + iy*nx)*nstep;
+            int ioff = (ix*ny + iy)*nstep;
             relaxTipStroke( probeStart, relaxAlg, nstep, rTips_+ioff*3, rs_+ioff*3, fs_+ioff*3, splineParams );
             if( omp_get_thread_num()==0 ){
                 ndone++;


### PR DESCRIPTION
Fixes #387.

* The crucial line to be fixed was in `ppafm.HighLevel.perform_relaxation()`.
* I have added the `--dist` option to `examples/FFPB_KPFM/run.sh` so that we have some example that checks the `--dist` functionality in the future.
* The change I have made in the `relaxTipStrokes_omp` function in `ppafm/cpp/ProbeParticle.cpp` is optional. The old definition of `ioff` values combined with the new definition of index order resulted in an erratic scanning of tip position in the _x_,_y_ directions. The code still worked because all points would be eventually visited, although in a nonsensical order, but I thought it would still be better to make it consistent with the new index order.
* Finally, I have removed the `meshgrid3d` function from `ppafm/HighLevel.py`. It did nothing and could not do anything as it lacked any command for output: neither it had a return command nor did it any argument reassignment. It caught my attention when I was checking how the `np.meshgrid` function works in the line I had to fix.